### PR TITLE
Add source syntax highlighting if pygments is available

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -11,6 +11,16 @@ import re
 import struct
 import termios
 
+syntax_highlighting_available = True
+try:
+    from pygments import highlight
+    from pygments.lexers import get_lexer_for_filename
+    from pygments.lexers import CppLexer
+    from pygments.formatters import Terminal256Formatter
+except ImportError:
+    syntax_highlighting_available = False
+
+
 # Common attributes ------------------------------------------------------------
 
 class R():
@@ -668,6 +678,9 @@ class Source(Dashboard.Module):
             if int(number) == current_line:
                 line_format = ansi(number_format + ' {}', R.style_selected_1)
             else:
+                if syntax_highlighting_available:
+                    lexer = get_lexer_for_filename(self.file_name)
+                    line = highlight(line, lexer, Terminal256Formatter())
                 line_format = ansi(number_format, R.style_low) + ' {}'
             out.append(line_format.format(number, line.rstrip('\n')))
         return out


### PR DESCRIPTION
Hi, thanks for this cool script, it made debugging with gdb much easier and more convenient for me. However, it's also really helpfull to have syntax highlighting in Source module, cause it makes code more readable. Sorry, that I didn't create an issue and ask you what do you think about it in general, but this patch is tiny, so I thought that I can just create a pull request. Is it okay for you? I tried to do it in such a way that if user has no pygments installed, highlighting will be disabled, so dashboard doesn't get a new dependency.