### PR TITLE
Don't fail if register name contains a dot

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1217,6 +1217,9 @@ class Registers(Dashboard.Module):
         for reg_info in run('info registers').strip().split('\n'):
             # fetch register and update the table
             name = reg_info.split(None, 1)[0]
+            # Exclude registers with a dot '.' or parse_and_eval() will fail
+            if '.' in name:
+                continue
             value = gdb.parse_and_eval('${}'.format(name))
             string_value = self.format_value(value)
             changed = self.table and (self.table.get(name, '') != string_value)


### PR DESCRIPTION
Dashboard registers processes all register names through parse_and_eval()
to get the register value. If register name contains a '.', we get the
error message:

    Attempt to extract a component of a value that is not a structure

To circumvent this, we simply ignore register whose name contains a '.'.
A better solution would be to extract the register value from output
of 'info registers'.