### PR TITLE
Convert filter output to list before calling len

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -680,7 +680,7 @@ files."""
                     def find_module(x):
                         return x.name == name
                     first_part = modules[:last]
-                    if len(filter(find_module, first_part)) == 0:
+                    if len(list(filter(find_module, first_part))) == 0:
                         Dashboard.err('Cannot find module "{}"'.format(name))
                     else:
                         Dashboard.err('Module "{}" already set'.format(name))


### PR DESCRIPTION
In python3, filter returns an iterator, which does not have a len method and, therefore, fails.