### PR TITLE
Add tabsize attribute to Source module

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -190,7 +190,7 @@ def format_address(address):
     return ('0x{{:0{}x}}').format(pointer_size * 2).format(address)
 
 class Highlighter():
-    def __init__(self, filename):
+    def __init__(self, filename, tabsize=8):
         self.active = False
         if not R.ansi:
             return
@@ -201,6 +201,8 @@ class Highlighter():
             formatter_class = pygments.formatters.Terminal256Formatter
             self.formatter = formatter_class(style=R.syntax_highlighting)
             self.lexer = pygments.lexers.get_lexer_for_filename(filename)
+            from pygments.filters import VisibleWhitespaceFilter
+            self.lexer.add_filter(VisibleWhitespaceFilter(tabsize=tabsize, tabs=' '))
             self.active = True
         except ImportError:
             # Pygments not available
@@ -794,7 +796,7 @@ class Source(Dashboard.Module):
             self.file_name = file_name
             self.ts = ts
             try:
-                highlighter = Highlighter(self.file_name)
+                highlighter = Highlighter(self.file_name, tabsize=self.tabsize)
                 self.highlighted = highlighter.active
                 with open(self.file_name) as source_file:
                     source = highlighter.process(source_file.read())
@@ -835,6 +837,12 @@ class Source(Dashboard.Module):
                 'default': 5,
                 'type': int,
                 'check': check_ge_zero
+            },
+            'tabsize': {
+                'doc': 'Number of spaces used for the <Tab> character. Applied only if syntax highlighting is enabled.',
+                'default': 8,
+                'type': int,
+                'check': check_gt_zero
             }
         }
 


### PR DESCRIPTION
Hi,

By default, a tab character is expanded to 8 spaces in the Source module (both when highlighting is enabled or not). This PR allows the user to change the tabsize.

```
dashboard source -style tabsize 4
```

What do you think?