### PR TITLE
Turn on pending breakpoint

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1521,6 +1521,7 @@ end
 
 # Better GDB defaults ----------------------------------------------------------
 
+set breakpoint pending on
 set history save
 set confirm off
 set verbose off


### PR DESCRIPTION
When the `break` command cannot resolve breakpoint, the unrecognized breakpoint location should automatically result in a pending breakpoint. This feature is very useful, especially when debugging a shared library.