### PR TITLE
Enable pending breakpoints

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -393,6 +393,7 @@ class Dashboard(gdb.Command):
         Dashboard.parse_inits(False)
         # GDB overrides
         run('set pagination off')
+        run('set breakpoint pending on')
         # enable and display if possible (program running)
         dashboard.enable()
         dashboard.redisplay()


### PR DESCRIPTION
gdb can set breakpoints for (undefined) functions that will be called in future shared libraries (aka pending breakpoints). This pull request turns on this useful feature.