### PR TITLE
support gdb 7.6.1

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -13,6 +13,9 @@ import termios
 import traceback
 import math
 
+if not hasattr(gdb, 'COMPLETE_EXPRESSION'):
+    gdb.COMPLETE_EXPRESSION = gdb.COMPLETE_SYMBOL
+
 # Common attributes ------------------------------------------------------------
 
 class R():

--- a/README.md
+++ b/README.md
@@ -468,8 +468,8 @@ available:
 Minimal requirements
 --------------------
 
-GDB dashboard requires at least GDB 7.7 compiled with Python 2.7 in order to
-work properly.
+GDB dashboard requires at least GDB 7.6.1 compiled with
+Python 2.7 in order to work properly.
 
 See [#1](https://github.com/cyrus-and/gdb-dashboard/issues/1) for more
 details/workarounds.


### PR DESCRIPTION
This works perfectly under my laptop.
gdb and python versions are listed below.

kimi@10.0.2.15:/home/kimi/gdb-8.1$ gdb -v
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-80.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.


kimi@10.0.2.15:/home/kimi/gdb-8.1$ python 
Python 2.7.5 (default, Nov 20 2015, 02:00:19) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
