### PR TITLE
Continue to write other modules when error happens in one module

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -380,18 +380,23 @@ class Dashboard(gdb.Command):
                     continue
                 # process all the modules for that output
                 for n, instance in enumerate(instances, 1):
-                    # skip disabled modules
-                    if not instance:
+                    try:
+                        # skip disabled modules
+                        if not instance:
+                            continue
+                        # ask the module to generate the content
+                        lines = instance.lines(width, style_changed)
+                        # create the divider accordingly
+                        div = divider(width, instance.label(), True, lines)
+                        # write the data
+                        fs.write('\n'.join([div] + lines))
+                        # write the newline for all but last unless main terminal
+                        if n != len(instances) or fs is gdb:
+                            fs.write('\n')
+                    except Exception as e:
+                        cause = traceback.format_exc().strip()
+                        Dashboard.err('Cannot write the module \'{0}\'\n{1}'.format(instance.label(), cause))
                         continue
-                    # ask the module to generate the content
-                    lines = instance.lines(width, style_changed)
-                    # create the divider accordingly
-                    div = divider(width, instance.label(), True, lines)
-                    # write the data
-                    fs.write('\n'.join([div] + lines))
-                    # write the newline for all but last unless main terminal
-                    if n != len(instances) or fs is gdb:
-                        fs.write('\n')
                 # write the final newline and the terminator only if it is the
                 # main terminal to allow the prompt to display correctly (unless
                 # there are no modules to display)


### PR DESCRIPTION
Sometimes there are errors when handling output of a specific module.
At present the dashboard just stops processing other modules, and
throws an exception message to the terminal.

Change to continue to write other modules in such situation.