### PR TITLE
Fix usage of max for python<3.4

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1105,7 +1105,11 @@ instructions constituting the current statement are marked, if available."""
             max_offset = max(len(str(abs(asm[0]['addr'] - func_start))),
                              len(str(abs(asm[-1]['addr'] - func_start))))
         # return the machine code
-        max_length = max((instr['length'] for instr in asm), default=0)
+        try:
+            max_length = max((instr['length'] for instr in asm))
+        except ValueError:
+            # asm is empty, use default value
+            max_length = 0
         inferior = gdb.selected_inferior()
         out = []
         for index, instr in enumerate(asm):


### PR DESCRIPTION
default argument of max is only available in python3.4+

Current implementation breaks gdb-dashboard asm dashboard in gdb bundled with python2.7