### PR TITLE
Parse breakpoint number as decimal

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -298,7 +298,7 @@ def fetch_breakpoints(watchpoints=False, pending=False):
             continue
         # extract breakpoint number, address and pending status
         fields = line.split()
-        number = int(fields[0], 16)
+        number = int(fields[0])
         is_pending = fields[4] == '<PENDING>'
         try:
             address = int(fields[4], 16) if len(fields) >= 5 and fields[1] == 'breakpoint' else None


### PR DESCRIPTION
The breakpoint number should be parsed as decimal number, instead it was parsed as hexadecimal. Since `int("10",16)==16`, we fill `parsed_breakpoints[16]` on [line 307](https://github.com/cyrus-and/gdb-dashboard/compare/master...alfunx:breakpoint-nr-decimal?expand=1#diff-7a539aea416e517dba63bf35ebad2327L307). This leads to a `KeyError` on [line 313](https://github.com/cyrus-and/gdb-dashboard/compare/master...alfunx:breakpoint-nr-decimal?expand=1#diff-7a539aea416e517dba63bf35ebad2327L313), where we access `parsed_breakpoints[10]` instead.