### PR TITLE
Fix exceptions caused by periods in breakpoint numbers (breakpoints with sub-breakpoints)

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -299,11 +299,11 @@ def fetch_breakpoints(watchpoints=False, pending=False):
         # extract breakpoint number, address and pending status
         fields = line.split()
         number = int(fields[0].split('.')[0])
-        is_pending = fields[4] == '<PENDING>'
-        is_multiple = fields[4] == '<MULTIPLE>'
         try:
             if len(fields) >= 5 and fields[1] == 'breakpoint':
                 # multiple breakpoints have no address yet
+                is_pending = fields[4] == '<PENDING>'
+                is_multiple = fields[4] == '<MULTIPLE>'
                 address = None if is_multiple or is_pending else int(fields[4], 16)
                 is_enabled = fields[3] == 'y'
                 address_info = address, is_enabled

--- a/.gdbinit
+++ b/.gdbinit
@@ -304,7 +304,7 @@ def fetch_breakpoints(watchpoints=False, pending=False):
         try:
             if len(fields) >= 5 and fields[1] == 'breakpoint':
                 # multiple breakpoints have no address yet
-                addresses = [] if is_multiple else [int(fields[4], 16)]
+                addresses = [] if is_multiple or is_pending else [int(fields[4], 16)]
                 parsed_breakpoints[number] = addresses, is_pending
             elif len(fields) >= 3 and number in parsed_breakpoints:
                 # add this address to the list of multiple locations
@@ -1144,9 +1144,8 @@ class Source(Dashboard.Module):
             end = len(self.source_lines)
         else:
             end = max(end, 0)
-        # find the breakpoints for the current file
-        breakpoints = list(filter(lambda x: x.get('file_name') == file_name, fetch_breakpoints()))
         # return the source code listing
+        breakpoints = fetch_breakpoints()
         out = []
         number_format = '{{:>{}}}'.format(len(str(end)))
         for number, line in enumerate(self.source_lines[start:end], start + 1):


### PR DESCRIPTION
In certain cases, a single breakpoint (for a single source line) can correspond to many multiple memory locations in the compiled program. In these cases, gdb (info breakpoints) will display these "sub-breakpoints" with numbers such as `1.1` and `1.2`. For an example, see the example program in the testing folder on my `subbreakpoint` branch.

With this change, `fetch_breakpoints()` does not throw an exception any more when encountering these numbers. Further, the multiple addresses of these single breakpoints (and possibly multiple source locations) are now also shown in the dashboard.