### PR TITLE
Use full file name in source module.

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1114,7 +1114,7 @@ class Source(Dashboard.Module):
         if current_line == 0:
             return []
         # reload the source file if changed
-        file_name = sal.symtab.filename
+        file_name = sal.symtab.fullname()
         ts = None
         try:
             ts = os.path.getmtime(file_name)


### PR DESCRIPTION
I had a problem where the dashboard would display an error message in the source module telling me it could not find the source file under a relative path. Changing the below line fixed this for me and I believe it should not break anything.

Tested on GDB 8.2 with Python 2.7 and  GDB 8.3.1 with Python 3.7.