### PR TITLE
Align names in column in Variable frame

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1505,11 +1505,10 @@ class Variables(Dashboard.Module):
                 'type': bool
             },
             'align': {
-                'doc': 'Align variables in column flag.',
-                'default': True,
+                'doc': 'Align variables in column flag (only if not compact).',
+                'default': False,
                 'type': bool
             }
-
         }
 
     @staticmethod
@@ -1591,7 +1590,7 @@ Optionally list the frame arguments and locals too.'''
             frame_lines = []
             frame_lines.append('[{}] {}'.format(frame_id, info))
             # add frame arguments and locals
-            variables = Variables.format_frame(frame, self.show_arguments, self.show_locals, self.compact)
+            variables = Variables.format_frame(frame, self.show_arguments, self.show_locals, self.compact, False)
             frame_lines.extend(variables)
             # add frame
             frames.append(frame_lines)

--- a/.gdbinit
+++ b/.gdbinit
@@ -1483,7 +1483,7 @@ class Variables(Dashboard.Module):
 
     def lines(self, term_width, term_height, style_changed):
         return Variables.format_frame(
-            gdb.selected_frame(), self.show_arguments, self.show_locals, self.compact)
+            gdb.selected_frame(), self.show_arguments, self.show_locals, self.compact, self.align)
 
     def attributes(self):
         return {
@@ -1503,11 +1503,17 @@ class Variables(Dashboard.Module):
                 'doc': 'Single-line display flag.',
                 'default': True,
                 'type': bool
+            },
+            'align': {
+                'doc': 'Align variables in column flag.',
+                'default': True,
+                'type': bool
             }
+
         }
 
     @staticmethod
-    def format_frame(frame, show_arguments, show_locals, compact):
+    def format_frame(frame, show_arguments, show_locals, compact, align):
         out = []
         # fetch frame arguments and locals
         decorator = gdb.FrameDecorator.FrameDecorator(frame)
@@ -1516,7 +1522,7 @@ class Variables(Dashboard.Module):
             def prefix(line):
                 return Stack.format_line('arg', line)
             frame_args = decorator.frame_args()
-            args_lines = Variables.fetch(frame, frame_args, compact)
+            args_lines = Variables.fetch(frame, frame_args, compact, align)
             if args_lines:
                 if compact:
                     args_line = separator.join(args_lines)
@@ -1528,7 +1534,7 @@ class Variables(Dashboard.Module):
             def prefix(line):
                 return Stack.format_line('loc', line)
             frame_locals = decorator.frame_locals()
-            locals_lines = Variables.fetch(frame, frame_locals, compact)
+            locals_lines = Variables.fetch(frame, frame_locals, compact, align)
             if locals_lines:
                 if compact:
                     locals_line = separator.join(locals_lines)
@@ -1539,9 +1545,11 @@ class Variables(Dashboard.Module):
         return out
 
     @staticmethod
-    def fetch(frame, data, compact):
+    def fetch(frame, data, compact, align):
         lines = []
-        name_width = max(len(str(elem.sym)) for elem in data or [])
+        name_width = 0
+        if align and not compact:
+            name_width = max(len(str(elem.sym)) for elem in data or [])
         for elem in data or []:
             name = ansi(str(elem.sym).ljust(name_width), R.style_high)
             equal = ansi('=', R.style_low)

--- a/.gdbinit
+++ b/.gdbinit
@@ -1541,8 +1541,9 @@ class Variables(Dashboard.Module):
     @staticmethod
     def fetch(frame, data, compact):
         lines = []
+        name_width = max(len(str(elem.sym)) for elem in data or [])
         for elem in data or []:
-            name = ansi(elem.sym, R.style_high)
+            name = ansi(str(elem.sym).ljust(name_width), R.style_high)
             equal = ansi('=', R.style_low)
             value = format_value(elem.sym.value(frame), compact)
             lines.append('{} {} {}'.format(name, equal, value))


### PR DESCRIPTION
Hi,

In the Variables frame, when variables names have varying name lengths the frame layout can look a bit messy and hard to visualise. I have added here a parameter to align the variables names in column when the compact style is not use. In short it goes from:

```
─── Variables ────────...
arg long_variable_name = ( regname = 'test_regname', table = 0x1de0140, size = 10, next = 0x0 )
arg short = 1
loc other_long_name = 0x1de0143
loc i = 3
loc other_thing = 0x0: Cannot access memory at address 0x0
```
to
```
─── Variables ────────...
arg long_variable_name = ( regname = 'test_negname', table = 0x1de0140, size = 10, next = 0x0 )
arg short              = 1
loc other_long_name = 0x1de0143
loc i               = 3
loc other_thing     = 0x0: Cannot access memory at address 0x0
```
Happy to hear any comments about it, and thanks for your work on gdb-dashboard, it has been a very useful tool.

