### PR TITLE
Allow ~/.gdbinit.d/ to be a symbolic link

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -616,7 +616,10 @@ class Dashboard(gdb.Command):
 
     @staticmethod
     def parse_inits(python):
-        for root, dirs, files in os.walk(os.path.expanduser('~/.gdbinit.d/')):
+        init_d = '~/.gdbinit.d/'
+        if(os.path.islink(init_d)):
+            init_d = os.path.realpath(init_d)
+        for root, dirs, files in os.walk(os.path.expanduser(init_d)):
             dirs.sort()
             for init in sorted(files):
                 path = os.path.join(root, init)


### PR DESCRIPTION
If ~/.gdbinit.d/ is a symbolic link, follow that link before parsing the init files.

Motivation: I like to keep my dotfiles for various programs in a single, version controlled directory. This allows easy synchronization between different machines, but in this case gdb-dashboard did not allow for ~/.gdb_init.d/ to be a symbolic link.