### PR TITLE
Reverse the order of frames in the Stack display.

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1616,6 +1616,7 @@ Optionally list the frame arguments and locals too.'''
         # add the placeholder
         if more:
             lines.append('[{}]'.format(ansi('+', R.style_selected_2)))
+        lines.reverse()
         return lines
 
     def attributes(self):


### PR DESCRIPTION
When the stack is displayed in ascending frame order, frames close to
%rip can scroll out of a tmux pane.  Reversing the display order makes
frame 0 and nearby frames more likely to be displayed.