### PR TITLE
Shorten long function names in the assembly view.

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1388,24 +1388,29 @@ The instructions constituting the current statement are marked, if available.'''
             if addr == frame.pc():
                 if not R.ansi:
                     indicator = '> '
-                addr_str = ansi(addr_str, R.style_selected_1)
-                indicator = ansi(indicator, R.style_selected_1)
-                opcodes = ansi(opcodes, R.style_selected_1)
-                func_info = ansi(func_info, R.style_selected_1)
-                if not highlighter.active:
-                    text = ansi(text, R.style_selected_1)
+                func_info_style = R.style_selected_1
+                addr_str_style = R.style_selected_1
             elif line_info and line_info.pc <= addr < line_info.last:
                 if not R.ansi:
                     indicator = ': '
-                addr_str = ansi(addr_str, R.style_selected_2)
-                indicator = ansi(indicator, R.style_selected_2)
-                opcodes = ansi(opcodes, R.style_selected_2)
-                func_info = ansi(func_info, R.style_selected_2)
-                if not highlighter.active:
-                    text = ansi(text, R.style_selected_2)
+                addr_str_style = R.style_selected_2
+                func_info_style = R.style_selected_2
             else:
                 addr_str = ansi(addr_str, R.style_low)
-                func_info = ansi(func_info, R.style_low)
+                func_info_style = R.style_low
+            addr_str = ansi(addr_str, func_info_style)
+            indicator = ansi(indicator, func_info_style)
+            opcodes = ansi(opcodes, func_info_style)
+            if not highlighter.active:
+                text = ansi(text, func_info_style)
+            if len(func_info) > R.max_value_length:
+                # Remove from the middle.
+                func_length = R.max_value_length / 2
+                func_info = (
+                    ansi(func_info[0:func_length/2], func_info_style) +
+                    ansi(R.value_truncation_string, R.style_critical) +
+                    ansi(func_info[-func_length/2:], func_info_style)
+                )
             # check for breakpoint presence
             enabled = None
             for breakpoint in breakpoints:


### PR DESCRIPTION
This is an experimental attempt to prevent functions with long call
signatures from wrapping the Assembly view.  It's thwarted by the
disassembly also including long call signatures in branch targets.

I briefly considered hacking the disassembler output, but the embedded
syntax highlighting makes that more difficult than I wanted to tackle.
Guess I'll just need to refactor the code I work on to pass structures
around instead. :)

`func_length` is half `R.max_value_length` because it was intended to
truncate function names twice: once for the function on every line,
and again for the branch targets.  I may take another pass at shortening
the branch targets if they keep bothering me.