### PR TITLE
Improve default color for gray

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -107,7 +107,7 @@ See the `prompt` attribute. This value is used as a Python format string where
                 'doc': '''Define the value of `{status}` when the target program is running.
 
 See the `prompt` attribute. This value is used as a Python format string.''',
-                'default': '\[\e[1;30m\]>>>\[\e[0m\]'
+                'default': '\[\e[90m\]>>>\[\e[0m\]'
             },
             # divider
             'omit_divider': {
@@ -129,7 +129,7 @@ See the `prompt` attribute. This value is used as a Python format string.''',
             },
             'divider_fill_style_secondary': {
                 'doc': 'Style for `divider_fill_char_secondary`',
-                'default': '1;30'
+                'default': '90'
             },
             'divider_label_style_on_primary': {
                 'doc': 'Label style for non-empty primary dividers',
@@ -145,7 +145,7 @@ See the `prompt` attribute. This value is used as a Python format string.''',
             },
             'divider_label_style_off_secondary': {
                 'doc': 'Label style for empty secondary dividers',
-                'default': '1;30'
+                'default': '90'
             },
             'divider_label_skip': {
                 'doc': 'Gap between the aligning border and the label.',
@@ -172,7 +172,7 @@ See the `prompt` attribute. This value is used as a Python format string.''',
                 'default': '32'
             },
             'style_low': {
-                'default': '1;30'
+                'default': '90'
             },
             'style_high': {
                 'default': '1;37'


### PR DESCRIPTION
A couple of styles by default use 1;30. However 30 stands for black and
1 stands for bold or increased intensity. So depending on the
interpretation, 1;30 may simply result in black. For terminals with a
black or dark background that interpret 1 not as increased intensity,
the output text is therefore not or almost not readable.

This is the case for gvim or neovim (with termguicolors set) but also
for some colorschemes of konsole, and probably others. In the case of
gvim/neovim this impacts the :TermDebug use case.

Since the original intent of 1;30 was probably to obtain a gray, this
change sets all occurences of 1;30 to 0;90, which results in gray again,
but without relying on the interpretation of 1 as an high-intense
modifier.