### PR TITLE
handle UnicodeDecodeerror in source files

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -34,6 +34,7 @@ import os
 import re
 import struct
 import traceback
+from io import open
 
 # Common attributes ------------------------------------------------------------
 
@@ -1173,7 +1174,7 @@ class Source(Dashboard.Module):
         if style_changed or file_name != self.file_name or ts and ts > self.ts:
             try:
                 # reload the source file if changed
-                with open(file_name) as source_file:
+                with open(file_name, errors='ignore') as source_file:
                     highlighter = Beautifier(file_name, self.tab_size)
                     self.highlighted = highlighter.active
                     source = highlighter.process(source_file.read())


### PR DESCRIPTION
Dealing with bad encoded source file will result in:
Traceback (most recent call last):
  File "<string>", line 538, in render
  File "<string>", line 1178, in lines
  File "/usr/lib/python3.9/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa9 in position 1050: invalid start byte

This patch will try to address this issue according to:
https://docs.python.org/3/library/codecs.html#error-handlers