### PR TITLE
Catch KeyError when getting breakpoints

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -360,7 +360,7 @@ def fetch_breakpoints(watchpoints=False, pending=False):
     for gdb_breakpoint in gdb.breakpoints() or []:
         # skip internal breakpoints
         if gdb_breakpoint.number < 0:
-          continue
+            continue
         addresses, is_pending = parsed_breakpoints[gdb_breakpoint.number]
         is_pending = getattr(gdb_breakpoint, 'pending', is_pending)
         if not pending and is_pending:

--- a/.gdbinit
+++ b/.gdbinit
@@ -358,7 +358,10 @@ def fetch_breakpoints(watchpoints=False, pending=False):
     breakpoints = []
     # XXX in older versions gdb.breakpoints() returns None
     for gdb_breakpoint in gdb.breakpoints() or []:
-        addresses, is_pending = parsed_breakpoints[gdb_breakpoint.number]
+        try:
+            addresses, is_pending = parsed_breakpoints[gdb_breakpoint.number]
+        except KeyError:
+            continue
         is_pending = getattr(gdb_breakpoint, 'pending', is_pending)
         if not pending and is_pending:
             continue

--- a/.gdbinit
+++ b/.gdbinit
@@ -358,10 +358,10 @@ def fetch_breakpoints(watchpoints=False, pending=False):
     breakpoints = []
     # XXX in older versions gdb.breakpoints() returns None
     for gdb_breakpoint in gdb.breakpoints() or []:
-        try:
-            addresses, is_pending = parsed_breakpoints[gdb_breakpoint.number]
-        except KeyError:
-            continue
+        # skip internal breakpoints
+        if gdb_breakpoint.number < 0:
+          continue
+        addresses, is_pending = parsed_breakpoints[gdb_breakpoint.number]
         is_pending = getattr(gdb_breakpoint, 'pending', is_pending)
         if not pending and is_pending:
             continue


### PR DESCRIPTION
I would have talked to you before making the PR, but it's a really small bug fix.

I had the situation where getting the breakpoints failed because one of the `gdb_breakpoint.number` was `-1`. This resulted in error messages in the `Assembly` and the `Breakpoints` section.

The bug fix just ignores these invalid breakpoints. I still saw all my created breakpoints in my situation. So, there were indeed some invalid breakpoints.