### PR TITLE
Display file path in Source label

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1160,7 +1160,7 @@ class Source(Dashboard.Module):
         self.offset = 0
 
     def label(self):
-        return 'Source'
+        return 'Source' + (': ' + self.file_name if self.file_name else "")
 
     def lines(self, term_width, term_height, style_changed):
         # skip if the current thread is not stopped


### PR DESCRIPTION
When stepping througth huge code base, like  C++ STL, it may be hard to
figure out what's going on in tiny Source window without information
about file path. It seems, label is the best place for such inforation, as
it does not take additional screen space.