### PR TITLE
Add a way to provide a complete method to a gdb.Command

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -675,12 +675,17 @@ class Dashboard(gdb.Command):
     @staticmethod
     def create_command(name, invoke, doc, is_prefix, complete=None):
         if callable(complete):
-            Class = type('', (gdb.Command,), {'invoke': invoke,
-                                              'complete': complete,
-                                              '__doc__': doc})
+            Class = type('', (gdb.Command,), {
+                '__doc__': doc
+                'invoke': invoke,
+                'complete': complete
+            })
             Class(name, gdb.COMMAND_USER, prefix=is_prefix)
         else:
-            Class = type('', (gdb.Command,), {'invoke': invoke, '__doc__': doc})
+            Class = type('', (gdb.Command,), {
+                '__doc__': doc,
+                'invoke': invoke
+            })
             Class(name, gdb.COMMAND_USER, complete or gdb.COMPLETE_NONE, is_prefix)
 
     @staticmethod

--- a/.gdbinit
+++ b/.gdbinit
@@ -674,8 +674,14 @@ class Dashboard(gdb.Command):
 
     @staticmethod
     def create_command(name, invoke, doc, is_prefix, complete=None):
-        Class = type('', (gdb.Command,), {'invoke': invoke, '__doc__': doc})
-        Class(name, gdb.COMMAND_USER, complete or gdb.COMPLETE_NONE, is_prefix)
+        if callable(complete):
+            Class = type('', (gdb.Command,), {'invoke': invoke,
+                                              'complete': complete,
+                                              '__doc__': doc})
+            Class(name, gdb.COMMAND_USER, prefix=is_prefix)
+        else:
+            Class = type('', (gdb.Command,), {'invoke': invoke, '__doc__': doc})
+            Class(name, gdb.COMMAND_USER, complete or gdb.COMPLETE_NONE, is_prefix)
 
     @staticmethod
     def err(string):


### PR DESCRIPTION
Currently only a gdb.COMPLETE_xxx constant can be used to specify the complete policy of a Dashboad.Module commands. This patch allows to pass a callable that will provide a complete method to the gdb.Command.

An example:

```py
class Example(Dashboard.Module):
    """ Example """
    def __init__(self):
        super().__init__()

    def lines(self, term_width, term_height, style_changed):
        return []

    def do(self, arg):
        pass

    def do_complete(self, text, word):
        values = ['abc', 'aab', 'aaa']

	return [x for x in values if x.startswith(word)]

    def commands(self):
        return {
            'do': {
                'action': self.do,
                'doc': 'do something',
                'complete': self.do_complete,
            }
        }
```