### PR TITLE
Fix: register list cannot be parsed if Groups column is empty for some registers (e.g. arm)

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -2059,9 +2059,13 @@ The empty list (default) causes to show all the available registers.''',
         names = []
         for line in run('maintenance print register-groups').split('\n'):
             fields = line.split()
-            if len(fields) != 7:
+            if len(fields) == 7:
+                name, _, _, _, _, _, groups = fields
+            elif len(fields) == 6:
+                name, _, _, _, _, _ = fields
+                groups = 'general'
+            else:
                 continue
-            name, _, _, _, _, _, groups = fields
             if not re.match('\w', name):
                 continue
             for group in groups.split(','):


### PR DESCRIPTION
Amends the issue where Registers list throw exception as below when working with an ARM core. 
`maintenance print register-groups` output below.

```
Traceback (most recent call last):
  File "<string>", line 550, in render
  File "<string>", line 1989, in lines
ValueError: max() arg is an empty sequence
```

```
>>> maintenance print register-groups
 Name         Nr  Rel Offset    Size  Type            Groups
 r0            0    0      0       4 long
 r1            1    1      4       4 long
 r2            2    2      8       4 long
 r3            3    3     12       4 long
 r4            4    4     16       4 long
 r5            5    5     20       4 long
 r6            6    6     24       4 long
 r7            7    7     28       4 long
 r8            8    8     32       4 long
 r9            9    9     36       4 long
 r10          10   10     40       4 long
 r11          11   11     44       4 long
 r12          12   12     48       4 long
 sp           13   13     52       4 *1
 lr           14   14     56       4 long
 pc           15   15     60       4 *1
 ''           16   16     64       0 int0_t
 ''           17   17     64       0 int0_t
 ''           18   18     64       0 int0_t
 ''           19   19     64       0 int0_t
 ''           20   20     64       0 int0_t
 ''           21   21     64       0 int0_t
 ''           22   22     64       0 int0_t
 ''           23   23     64       0 int0_t
 ''           24   24     64       0 int0_t
 cpsr         25   25     64       4 long
 ''           26   26     68       0 int0_t
 ''           27   27     68       0 int0_t
 ''           28   28     68       0 int0_t
 ''           29   29     68       0 int0_t
 ''           30   30     68       0 int0_t
 ''           31   31     68       0 int0_t
 ''           32   32     68       0 int0_t
 ''           33   33     68       0 int0_t
 ''           34   34     68       0 int0_t
 ''           35   35     68       0 int0_t
 ''           36   36     68       0 int0_t
 ''           37   37     68       0 int0_t
 ''           38   38     68       0 int0_t
 ''           39   39     68       0 int0_t
 ''           40   40     68       0 int0_t
 ''           41   41     68       0 int0_t
 ''           42   42     68       0 int0_t
 ''           43   43     68       0 int0_t
 ''           44   44     68       0 int0_t
 ''           45   45     68       0 int0_t
 ''           46   46     68       0 int0_t
 ''           47   47     68       0 int0_t
 ''           48   48     68       0 int0_t
 ''           49   49     68       0 int0_t
 ''           50   50     68       0 int0_t
 ''           51   51     68       0 int0_t
 ''           52   52     68       0 int0_t
 ''           53   53     68       0 int0_t
 ''           54   54     68       0 int0_t
 ''           55   55     68       0 int0_t
 ''           56   56     68       0 int0_t
 ''           57   57     68       0 int0_t
 d0           58   58     68       8 double
 d1           59   59     76       8 double
 d2           60   60     84       8 double
 d3           61   61     92       8 double
 d4           62   62    100       8 double
 d5           63   63    108       8 double
 d6           64   64    116       8 double
 d7           65   65    124       8 double
 d8           66   66    132       8 double
 d9           67   67    140       8 double
 d10          68   68    148       8 double
 d11          69   69    156       8 double
 d12          70   70    164       8 double
 d13          71   71    172       8 double
 d14          72   72    180       8 double
 d15          73   73    188       8 double
 ''           74   74    196       0 int0_t
 ''           75   75    196       0 int0_t
 ''           76   76    196       0 int0_t
 ''           77   77    196       0 int0_t
 ''           78   78    196       0 int0_t
 ''           79   79    196       0 int0_t
 ''           80   80    196       0 int0_t
 ''           81   81    196       0 int0_t
 ''           82   82    196       0 int0_t
 ''           83   83    196       0 int0_t
 ''           84   84    196       0 int0_t
 ''           85   85    196       0 int0_t
 ''           86   86    196       0 int0_t
 ''           87   87    196       0 int0_t
 ''           88   88    196       0 int0_t
 ''           89   89    196       0 int0_t
 fpscr        90   90    196       4 long
 c0_cpuid     91   91    200       4 long
 c2_data      92   92    204       4 long
 c2_insn      93   93    208       4 long
 esr_el       94   94    212       4 long
 mpidr        95   95    216       4 long
 elr          96   96    220       4 long
 fpsid        97   97    224       4 long
 fpexc        98   98    228       4 long
 PMCCNTR      99   99    232       4 long            cp_regs
 PMUSERENR   100  100    236       4 long            cp_regs
 PMINTENSET  101  101    240       4 long            cp_regs
 PMOVSSET    102  102    244       4 long            cp_regs
 DBGBVR      103  103    248       4 long            cp_regs
 DBGBCR      104  104    252       4 long            cp_regs
 DBGWVR      105  105    256       4 long            cp_regs
 DBGWCR      106  106    260       4 long            cp_regs
 DBGDRAR     107  107    264       4 long            cp_regs
 DBGDSAR     108  108    268       4 long            cp_regs
 CNTP_CVAL   109  109    272       8 long long       cp_regs
 JIDR        110  110    280       4 long            cp_regs
 CNTV_CVAL   111  111    284       8 long long       cp_regs
 JOSCR       112  112    292       4 long            cp_regs
 JMCR        113  113    296       4 long            cp_regs
 CNTVOFF     114  114    300       8 long long       cp_regs
 CNTHP_CVAL  115  115    308       8 long long       cp_regs
 DBGDSCRint  116  116    316       4 long            cp_regs
 OSLSR_EL1   117  117    320       4 long            cp_regs
 PMCCFILTR   118  118    324       4 long            cp_regs
 PAR         119  119    328       8 long long       cp_regs
 CTR         120  120    336       4 long            cp_regs
 TCMTR       121  121    340       4 long            cp_regs
 MPUIR       122  122    344       4 long            cp_regs
 REVIDR_EL1  123  123    348       4 long            cp_regs
 MIDR        124  124    352       4 long            cp_regs
 CPACR       125  125    356       4 long            cp_regs
 CLIDR       126  126    360       4 long            cp_regs
 SCTLR       127  127    364       4 long            cp_regs
 ACTLR_EL1   128  128    368       4 long            cp_regs
 AIDR        129  129    372       4 long            cp_regs
 CSSELR      130  130    376       4 long            cp_regs
 DACR        131  131    380       4 long            cp_regs
 DFSR        132  132    384       4 long            cp_regs
 IFSR        133  133    388       4 long            cp_regs
 DBGDRAR     134  134    392       8 long long       cp_regs
 VPIDR       135  135    400       4 long            cp_regs
 DFAR        136  136    404       4 long            cp_regs
 WFAR        137  137    408       4 long            cp_regs
 IFAR        138  138    412       4 long            cp_regs
 SCTLR_EL2   139  139    416       4 long            cp_regs
 VMPIDR      140  140    420       4 long            cp_regs
 ACTLR_EL2   141  141    424       4 long            cp_regs
 TCR_EL2     142  142    428       4 long            cp_regs
 MDSCR_EL1   143  143    432       4 long            cp_regs
 FAR_EL2     144  144    436       4 long            cp_regs
 HIFAR       145  145    440       4 long            cp_regs
 HPFAR       146  146    444       4 long            cp_regs
 FCSEIDR     147  147    448       4 long            cp_regs
 CONTEXTIDR_EL1  148  148    452       4 long            cp_regs
 TPIDRURW    149  149    456       4 long            cp_regs
 TPIDRURO    150  150    460       4 long            cp_regs
 TPIDRPRW    151  151    464       4 long            cp_regs
 PMEVCNTR0   152  152    468       4 long            cp_regs
 PMEVCNTR1   153  153    472       4 long            cp_regs
 PMEVCNTR2   154  154    476       4 long            cp_regs
 PMEVCNTR3   155  155    480       4 long            cp_regs
 CNTFRQ      156  156    484       4 long            cp_regs
 VBAR        157  157    488       4 long            cp_regs
 VBAR_EL2    158  158    492       4 long            cp_regs
 TPIDR_EL2   159  159    496       4 long            cp_regs
 ID_PFR0     160  160    500       4 long            cp_regs
 ID_DFR0     161  161    504       4 long            cp_regs
 ID_AFR0     162  162    508       4 long            cp_regs
 ID_MMFR0    163  163    512       4 long            cp_regs
 ID_MMFR1    164  164    516       4 long            cp_regs
 ID_MMFR2    165  165    520       4 long            cp_regs
 ID_MMFR3    166  166    524       4 long            cp_regs
 NSACR       167  167    528       4 long            cp_regs
 DBGDSAR     168  168    532       8 long long       cp_regs
 AFSR0_EL1   169  169    540       4 long            cp_regs
 CPTR_EL2    170  170    544       4 long            cp_regs
 VTCR        171  171    548       4 long            cp_regs
 HCR         172  172    552       4 long            cp_regs
 HACR_EL2    173  173    556       4 long            cp_regs
 IMP_BTCMREGIONR  174  174    560       4 long            cp_regs
 AFSR1_EL1   175  175    564       4 long            cp_regs
 IMP_ATCMREGIONR  176  176    568       4 long            cp_regs
 IMP_BTCTLR  177  177    572       4 long            cp_regs
 IMP_MEMPROTCTLR  178  178    576       4 long            cp_regs
 AFSR0_EL2   179  179    580       4 long            cp_regs
 IMP_CTCMREGIONR  180  180    584       4 long            cp_regs
 AFSR1_EL2   181  181    588       4 long            cp_regs
 MDCR_EL2    182  182    592       4 long            cp_regs
 HSTR_EL2    183  183    596       4 long            cp_regs
 CNTKCTL     184  184    600       4 long            cp_regs
 HCR2        185  185    604       4 long            cp_regs
 CNTHCTL_EL2  186  186    608       4 long            cp_regs
 ID_ISAR0    187  187    612       4 long            cp_regs
 ID_ISAR1    188  188    616       4 long            cp_regs
 ID_ISAR2    189  189    620       4 long            cp_regs
 ID_ISAR3    190  190    624       4 long            cp_regs
 ID_ISAR4    191  191    628       4 long            cp_regs
 ID_ISAR5    192  192    632       4 long            cp_regs
 ID_MMFR4    193  193    636       4 long            cp_regs
 ID_ISAR6    194  194    640       4 long            cp_regs
 MAIR0       195  195    644       4 long            cp_regs
 MAIR1       196  196    648       4 long            cp_regs
 ESR_EL2     197  197    652       4 long            cp_regs
 CNTP_CTL    198  198    656       4 long            cp_regs
 MAIR_EL2    199  199    660       4 long            cp_regs
 HMAIR1      200  200    664       4 long            cp_regs
 TTBR0       201  201    668       8 long long       cp_regs
 TTBR1       202  202    676       8 long long       cp_regs
 CNTHP_CTL_EL2  203  203    684       4 long            cp_regs
 HTTBR       204  204    688       8 long long       cp_regs
 ID_PFR2     205  205    696       4 long            cp_regs
 SDCR        206  206    700       4 long            cp_regs
 VTTBR       207  207    704       8 long long       cp_regs
 AMAIR0      208  208    712       4 long            cp_regs
 AMAIR1      209  209    716       4 long            cp_regs
 CNTV_CTL    210  210    720       4 long            cp_regs
 AMAIR_EL2   211  211    724       4 long            cp_regs
 HAMAIR1     212  212    728       4 long            cp_regs
 CBAR        213  213    732       4 long            cp_regs
 PAR         214  214    736       4 long            cp_regs
 PMCR        215  215    740       4 long            cp_regs
 PMCNTENSET  216  216    744       4 long            cp_regs
 PMCNTENCLR  217  217    748       4 long            cp_regs
 PMOVSR      218  218    752       4 long            cp_regs
 PMSELR      219  219    756       4 long            cp_regs
 PMCEID1     220  220    760       4 long            cp_regs
 PMEVTYPER0  221  221    764       4 long            cp_regs
 PMEVTYPER1  222  222    768       4 long            cp_regs
 PMEVTYPER3  223  223    772       4 long            cp_regs
 PMCEID0     224  224    776       4 long            cp_regs
 PMEVTYPER2  225  225    780       4 long            cp_regs
 s0          226    0    784       4 float
 s1          227    1    788       4 float
 s2          228    2    792       4 float
 s3          229    3    796       4 float
 s4          230    4    800       4 float
 s5          231    5    804       4 float
 s6          232    6    808       4 float
 s7          233    7    812       4 float
 s8          234    8    816       4 float
 s9          235    9    820       4 float
 s10         236   10    824       4 float
 s11         237   11    828       4 float
 s12         238   12    832       4 float
 s13         239   13    836       4 float
 s14         240   14    840       4 float
 s15         241   15    844       4 float
 s16         242   16    848       4 float
 s17         243   17    852       4 float
 s18         244   18    856       4 float
 s19         245   19    860       4 float
 s20         246   20    864       4 float
 s21         247   21    868       4 float
 s22         248   22    872       4 float
 s23         249   23    876       4 float
 s24         250   24    880       4 float
 s25         251   25    884       4 float
 s26         252   26    888       4 float
 s27         253   27    892       4 float
 s28         254   28    896       4 float
 s29         255   29    900       4 float
 s30         256   30    904       4 float
 s31         257   31    908       4 float
*1: Register type's name NULL.
```