### PR TITLE
Move the cursor to top-left corner when discard_scrollback is False

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -697,7 +697,7 @@ class Dashboard(gdb.Command):
         # ANSI: move the cursor to top-left corner and clear the screen
         # (optionally also clear the scrollback buffer if supported by the
         # terminal)
-        return '\x1b[H\x1b[J' + '\x1b[3J' if R.discard_scrollback else ''
+        return '\x1b[H\x1b[J' + ('\x1b[3J' if R.discard_scrollback else '')
 
     @staticmethod
     def setup_terminal():


### PR DESCRIPTION
This commit aligns the cursor behavior between `discard_scrollback = False` and `discard_scrollback = True` modes to sahre the common user experience of having new dashboard status in top-left corner of the screen.

The idea was discussed in #180 