### PR TITLE
Show all the stack during the frame jumps

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1652,16 +1652,17 @@ Optionally list the frame arguments and locals too.'''
         frame = gdb.newest_frame()
         while frame:
             if frame == gdb.selected_frame():
+                frame = gdb.newest_frame()
                 break
             frame = frame.older()
             selected_index += 1
         # format up to "limit" frames
         frames = []
-        number = selected_index
+        number = 0
         more = False
         while frame:
             # the first is the selected one
-            selected = (len(frames) == 0)
+            selected = (number == selected_index)
             # fetch frame info
             style = R.style_selected_1 if selected else R.style_selected_2
             frame_id = ansi(str(number), style)


### PR DESCRIPTION
Hey,

I would like to suggest a change with regards to stack output during the frame jumps. From my opinion, cutting the end of the stack when you are jumping between frames is not useful because it hides the full context of the bug being debugged.

The change is calculating the selected frame before the frame parsings and highlight it accordingly. Here is the screenshot when I jumped on `frame 2` after the breakpoint triggered. The output is stripped to not to violate the privacy
![image](https://user-images.githubusercontent.com/20692004/224536784-ff971027-38a8-434c-b61a-6abe529303fc.png)
