### PR TITLE
rewrite memory module to use GDB's "x" output

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1891,8 +1891,14 @@ class Memory(Dashboard.Module):
                                                      self.object_size)
                 else:
                     elem = str(memory[rel])
-                # save strlen because ANSI escape sequences are added later
-                elem_cont = [elem, len(elem)]
+                if self.object_base == 'i' or self.object_base == 's':
+                    # instructions and strings need no padding, but address
+                    # should be separated for formatting
+                    addr_sep = elem.index(':')
+                    elem_cont = [elem[addr_sep+1:], ansi(elem[:addr_sep+1], R.style_low)]
+                else:
+                    # save strlen to calculate padding because ANSI is added later
+                    elem_cont = [elem, len(elem)]
                 # differences against the latest have the highest priority
                 if self.latest and memory[rel] != self.latest[rel]:
                     elem_cont[0] = ansi(elem_cont[0], R.style_selected_1)
@@ -1915,12 +1921,9 @@ class Memory(Dashboard.Module):
             for elem_cont in elems:
                 # instructions and strings are left aligned and on a single line
                 if self.object_base == 'i' or self.object_base == 's':
-                    # address is included in element, format differently
-                    addr_sep = elem_cont[0].index(':')
                     line += '{}{}{}'.format(' ' * separation,
-                                            ansi(elem_cont[0][:addr_sep+1], R.style_low),
-                                            elem_cont[0][addr_sep+1:])
-                    #line = '{}'.format(ansi(address_str, R.style_low))
+                                            elem_cont[1],
+                                            elem_cont[0])
                 else:
                     line += '{}{}{}'.format(' ' * separation,
                                             ' ' * (elem_length - elem_cont[1]),
@@ -1959,7 +1962,7 @@ class Memory(Dashboard.Module):
             for i in range(0, len(memory), per_line_current):
                 pad = per_line_current - len(memory[i:i + per_line_current])
                 raw = self.format_compute_changes(memory, i, per_line_current, False)
-                # TODO instruction and string format don't have fixed size, so
+                # instruction and string format don't have fixed size, so
                 # address can't be calculated
                 if self.object_base == 'i' or self.object_base == 's':
                     line = ''


### PR DESCRIPTION
I missed a convenient way to constantly watch a memory region with the format options of GDB's "x" command (e. g. watching not only single bytes). This is a rewrite of the memory module to achieve this.

Instead of getting a raw memory dump like before, an "x" command is created, evaluated by GDB and its output is formatted according to the dashboard settings. The watch command of the previous memory module can be used and extended for backwards compatibility. Alternatively the watch command also accepts an "x" command as it would be entered into GDB directly.

I understand that this might not be a wanted feature to integrate as discussed in #21, but I find this very useful and wanted to leave this here for anyone interested even if it won't be integrated.

edit/added screenshot:
![screenshot](https://github.com/cyrus-and/gdb-dashboard/assets/81750792/2efd648d-2c85-4fd1-afc3-5756f8bf3fbe)