### PR TITLE
Add HARDWARE_BREAKPOINT support

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -2273,6 +2273,7 @@ class Breakpoints(Dashboard.Module):
 
     NAMES = {
         gdb.BP_BREAKPOINT: 'break',
+        gdb.BP_HARDWARE_BREAKPOINT: 'hw break',
         gdb.BP_WATCHPOINT: 'watch',
         gdb.BP_HARDWARE_WATCHPOINT: 'write watch',
         gdb.BP_READ_WATCHPOINT: 'read watch',


### PR DESCRIPTION
Dashboard used to not display breakpoint cause my breakpint were hardware one's. This add a string to the Breakpoints.NAMES dict so HW breakpoints would be displayed correctly