### PR TITLE
fix: tab completion broken with Python 3.12

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -36,6 +36,17 @@ import os
 import re
 import struct
 import traceback
+import importlib.abc
+
+# fix https://github.com/cyrus-and/gdb-dashboard/issues/325
+# fix from https://sourceware.org/bugzilla/show_bug.cgi?id=32473
+class GdbRemoveReadlineFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "readline":
+            raise ImportError("readline module disabled under GDB")
+        return None
+
+sys.meta_path.insert(0, GdbRemoveReadlineFinder())
 
 # Common attributes ------------------------------------------------------------
 


### PR DESCRIPTION
closes #325

The fix comes from gdb upstream @ https://sourceware.org/bugzilla/show_bug.cgi?id=32473