### PR TITLE
Add a shebang to allow users to run it directly

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S gdb -q -x
 python
 
 # GDB dashboard - Modular visual interface for GDB in Python.


### PR DESCRIPTION
Some Linux distributions warp it by `gdb -q -x`:

https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/gd/gdb-dashboard/package.nix#L30-L31
