### PR TITLE
Add autostep to breakpoint type names

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -2272,6 +2272,7 @@ class Breakpoints(Dashboard.Module):
     '''Display the breakpoints list.'''
 
     NAMES = {
+        23: 'autostep',
         gdb.BP_BREAKPOINT: 'break',
         gdb.BP_WATCHPOINT: 'watch',
         gdb.BP_HARDWARE_WATCHPOINT: 'write watch',


### PR DESCRIPTION
Refer https://docs.nvidia.com/cuda/cuda-gdb/index.html#autostep

![Image](https://github.com/user-attachments/assets/ddc24aa2-dbf5-4fa6-b23b-23c5e70a1483)
