### PR TITLE
Fix buffer overflow in get_term_size() when using TIOCGWINSZ ioctl

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -612,9 +612,11 @@ class Dashboard(gdb.Command):
             else:
                 import termios
                 import fcntl
-                # struct winsize is 8 bytes, but we only need the first 2 shorts (rows, cols)
-                raw = fcntl.ioctl(fd, termios.TIOCGWINSZ, b'\0' * 8)
-                height, width = struct.unpack('hh', raw[:4])
+                # first 2 shorts of struct winsize
+                winsize_format = 'hhhh'
+                buffer = b'\x00' * struct.calcsize(winsize_format)
+                buffer = fcntl.ioctl(fd, termios.TIOCGWINSZ, buffer)
+                height, width, _, _ = struct.unpack(winsize_format, buffer)
                 return int(width), int(height)
         except (ImportError, OSError, SystemError):
             # this happens when no curses library is found on windows or when

--- a/.gdbinit
+++ b/.gdbinit
@@ -612,11 +612,11 @@ class Dashboard(gdb.Command):
             else:
                 import termios
                 import fcntl
-                # first 2 shorts (4 byte) of struct winsize
-                raw = fcntl.ioctl(fd, termios.TIOCGWINSZ, ' ' * 4)
-                height, width = struct.unpack('hh', raw)
+                # struct winsize is 8 bytes, but we only need the first 2 shorts (rows, cols)
+                raw = fcntl.ioctl(fd, termios.TIOCGWINSZ, b'\0' * 8)
+                height, width = struct.unpack('hh', raw[:4])
                 return int(width), int(height)
-        except (ImportError, OSError):
+        except (ImportError, OSError, SystemError):
             # this happens when no curses library is found on windows or when
             # the terminal is not properly configured
             return 80, 24  # hardcoded fallback value


### PR DESCRIPTION
Fixes a `SystemError: buffer overflow` that occurs when the dashboard tries to get the terminal size using `fcntl.ioctl()` with `TIOCGWINSZ`.

### Problem
The current implementation allocates a 4-byte buffer for the `TIOCGWINSZ` ioctl call:
```python
raw = fcntl.ioctl(fd, termios.TIOCGWINSZ, ' ' * 4)
```

However, `TIOCGWINSZ` returns a complete `struct winsize` which is 8 bytes, not 4 bytes. According to the man page, the structure contains:
- `ws_row` (2 bytes) - terminal rows
- `ws_col` (2 bytes) - terminal columns
- `ws_xpixel` (2 bytes) - horizontal pixels
- `ws_ypixel` (2 bytes) - vertical pixels

When the ioctl attempts to write 8 bytes into a 4-byte buffer, Python raises a buffer overflow error.

### Solution
Changed the buffer size from 4 bytes to 8 bytes to accommodate the full `struct winsize`:
```python
raw = fcntl.ioctl(fd, termios.TIOCGWINSZ, ' ' * 8)
```

The code still only unpacks the first two shorts (height and width) as intended, but now provides adequate buffer space for the entire structure.

Also, we catch `SystemError` in the `except` block to fallback to the hardcoded values.